### PR TITLE
Create a playbook for installing elasticsearch.

### DIFF
--- a/elasticsearch/defaults/main.yaml
+++ b/elasticsearch/defaults/main.yaml
@@ -1,0 +1,3 @@
+---
+# This determines which elasticsearch repository we pull from.
+major_version: 1.5

--- a/elasticsearch/tasks/main.yaml
+++ b/elasticsearch/tasks/main.yaml
@@ -1,0 +1,17 @@
+---
+# Java (a prerequisite for elasticsearch)
+- name: Add Java PPA from webupd8team (elasticsearch requires a version than often newer than default openjre)
+  apt_repository: repo='ppa:webupd8team/java'
+- name: Accept Oracle Java 8 License
+  debconf: name='oracle-java8-installer' question='shared/accepted-oracle-license-v1-1' value='true' vtype='select'
+- name: Install Oracle Java 8
+  apt: pkg=oracle-java8-installer update_cache=yes state=present
+# elasticsearch!
+- name: Add elasticsearch APT key
+  apt_key: url=http://packages.elasticsearch.org/GPG-KEY-elasticsearch state=present
+- name: Add elasticsearch repository definition for version {{major_version}}
+  apt_repository: repo='deb http://packages.elasticsearch.org/elasticsearch/{{major_version}}/debian stable main' state=present
+- name: install elasticsearch
+  apt: pkg=elasticsearch update_cache=yes state=present
+- name: Set elasticsearch to start on boot and start right away
+  service: name=elasticsearch state=started enabled=yes


### PR DESCRIPTION
Uses Oracle Java 8 per version requirements and elasticsearch recommendation. So maybe controversial? From http://www.elastic.co/guide/en/elasticsearch/reference/current/setup.html:

> We recommend installing the Java 8 update 20 or later, or Java 7 update 55 or later. Previous versions of Java 7 are known to have bugs that can cause index corruption and data loss. Elasticsearch will refuse to start if a known-bad version of Java is used. [1.5.0]

Those aren't available as an openJRE in default Ubuntu PPA as far as I'm aware. Thoughts?
